### PR TITLE
Changed data models that handle raw response

### DIFF
--- a/app/src/main/java/com/example/cansearch/search/data/SearchResultRaw.kt
+++ b/app/src/main/java/com/example/cansearch/search/data/SearchResultRaw.kt
@@ -1,10 +1,10 @@
 package com.example.cansearch.search.data
 
+import com.example.cansearch.App
+import com.example.cansearch.R
 import com.example.cansearch.search.domain.SearchScreen
-import com.example.cansearch.search.ui.SearchListItem
-import com.example.cansearch.trial.ui.TrialEligibilityItem
-import com.example.cansearch.trial.ui.TrialSummaryItem
 import com.example.cansearch.search.domain.SearchScreen.SearchResult
+import com.example.cansearch.search.ui.SearchListItem
 import com.google.gson.annotations.SerializedName
 
 data class SearchResultRaw(
@@ -211,14 +211,28 @@ data class SearchResultRaw(
 
         // todo hard coded values
         private fun mapToTrialSummary(): SearchResult.TrialSummary {
-            val trialSummaryList = mutableListOf<TrialSummaryItem>()
-            trialSummaryList.add(TrialSummaryItem("Principle Investigator", principalInvestigator, false))
-            trialSummaryList.add(TrialSummaryItem("Lead Organization", leadOrganization, false))
-            trialSummaryList.add(TrialSummaryItem("Phase", phase.phase, true))
-            trialSummaryList.add(TrialSummaryItem("Activity Status", trialStatus, true))
-            trialSummaryList.add(TrialSummaryItem("Primary Purpose", primaryPurpose.phase, true))
-            trialSummaryList.add(TrialSummaryItem("Anatomic Site", "Breast", false))
-            return SearchResult.TrialSummary(trialSummaryList)
+            val trialSummaryHashMap = HashMap<String, Pair<String, String>>()
+
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_principle_investigator)] =
+                Pair(App.instance.getString(R.string.trial_summary_principle_investigator), principalInvestigator)
+
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_lead_organization)] =
+                Pair(App.instance.getString(R.string.trial_summary_lead_organization), leadOrganization)
+
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_phase)] =
+                Pair(App.instance.getString(R.string.trial_summary_phase), "Phase: ${phase.phase}")
+
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_activity_status)] =
+                Pair(App.instance.getString(R.string.trial_summary_activity_status), trialStatus)
+
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_primary_purpose)] =
+                Pair(App.instance.getString(R.string.trial_summary_primary_purpose), primaryPurpose.phase)
+
+            // todo - add this raw model
+            trialSummaryHashMap[App.instance.getString(R.string.trial_summary_anatomic_site)] =
+                Pair(App.instance.getString(R.string.trial_summary_anatomic_site), "Lung")
+
+            return SearchResult.TrialSummary(trialSummaryHashMap)
         }
 
         // todo hard coded values
@@ -248,11 +262,21 @@ data class SearchResultRaw(
 
         // todo hard coded values
         private fun mapToEligibility(): SearchResult.Eligibility {
-            val eligibilities = mutableListOf<TrialEligibilityItem>()
-            eligibilities.add(TrialEligibilityItem("Gender", eligibility.structured.gender))
-            eligibilities.add(TrialEligibilityItem("Minimum Age", "${eligibility.structured.minAgeInYears}"))
-            eligibilities.add(TrialEligibilityItem("Max Age", "${eligibility.structured.maxAgeInYears}"))
-            return SearchResult.Eligibility(eligibilities)
+
+            val trialEligibilityHashMap = HashMap<String, Pair<String, String>>()
+
+            trialEligibilityHashMap[App.instance.getString(R.string.trial_eligibility_gender)] =
+                Pair(App.instance.getString(R.string.trial_eligibility_gender), eligibility.structured.gender)
+
+            trialEligibilityHashMap[App.instance.getString(R.string.trial_eligibility_min_age)] =
+                Pair(App.instance.getString(R.string.trial_eligibility_gender), "${eligibility.structured.minAgeInYears}")
+
+            val maxAge = if (eligibility.structured.maxAgeInYears == 999) "NA" else "${eligibility.structured.maxAgeInYears}"
+
+            trialEligibilityHashMap[App.instance.getString(R.string.trial_eligibility_max_age)] =
+                Pair(App.instance.getString(R.string.trial_eligibility_max_age), maxAge)
+
+            return SearchResult.Eligibility(trialEligibilityHashMap)
         }
     }
 }

--- a/app/src/main/java/com/example/cansearch/search/domain/SearchResultSummary.kt
+++ b/app/src/main/java/com/example/cansearch/search/domain/SearchResultSummary.kt
@@ -1,5 +1,8 @@
 package com.example.cansearch.search.domain
 
+import com.example.cansearch.App
+import com.example.cansearch.R
+
 data class SearchResultSummary(
     val id: String,
     val briefTitle: String,
@@ -13,11 +16,16 @@ data class SearchResultSummary(
             SearchResultSummary(
                 id = searchResult.id,
                 briefTitle = searchResult.studySummary.briefTitle,
-                principleInvestigator = "Dr Matt Taila",
-                leadOrganization = "TGen",
-                phase = "Phase",
+                principleInvestigator = returnValue(searchResult, R.string.trial_summary_principle_investigator),
+                leadOrganization = returnValue(searchResult, R.string.trial_summary_lead_organization),
+                phase = returnValue(searchResult, R.string.trial_summary_phase),
                 totalSites = "12312 total sites"
             )
+
+        private fun returnValue(searchResult: SearchScreen.SearchResult, stringId: Int) : String {
+            return searchResult.trialSummary.summaryItems[App.instance.getString(stringId)]!!.second
+        }
     }
+
 
 }

--- a/app/src/main/java/com/example/cansearch/search/domain/SearchScreen.kt
+++ b/app/src/main/java/com/example/cansearch/search/domain/SearchScreen.kt
@@ -26,7 +26,7 @@ data class SearchScreen(val totalResults: Int, val searchResults: List<SearchRes
 
         // this needs to be a key value map instead of a list
         data class TrialSummary(
-            val summaryItems: MutableList<TrialSummaryItem>
+            val summaryItems: HashMap<String, Pair<String, String>>
         )
 
         data class AssociatedDiseases(
@@ -38,7 +38,7 @@ data class SearchScreen(val totalResults: Int, val searchResults: List<SearchRes
         )
 
         data class Eligibility(
-            val eligibilityCriteria: MutableList<TrialEligibilityItem>
+            val eligibilityCriteria: HashMap<String, Pair<String, String>>
         )
 
         private fun mapToSearchResultsSummary(): SearchResultSummary {

--- a/app/src/main/res/values/trial_keys.xml
+++ b/app/src/main/res/values/trial_keys.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--// Summary-->
+    <string name="trial_summary_principle_investigator">Principle Investigator</string>
+    <string name="trial_summary_lead_organization">Lead Organization</string>
+    <string name="trial_summary_phase">Phase</string>
+    <string name="trial_summary_activity_status">Activity Status</string>
+    <string name="trial_summary_primary_purpose">Primary Purpose</string>
+    <string name="trial_summary_anatomic_site">Anatomic Site</string>
+
+    <!--// Eligibility-->
+    <string name="trial_eligibility_gender">Gender</string>
+    <string name="trial_eligibility_min_age">Minimum Age</string>
+    <string name="trial_eligibility_max_age">Maximum Age</string>
+</resources>


### PR DESCRIPTION
## Changes
    - Opted to use a HashMap<String, <Pair<String, String>> to represent trial summary and criteria. This could be transformed into a list later on for the detailed fragment, but there are particular instances where I specifically need certain fields (such as principleInvestigator), and so using the hashmap structure I can easily do this. 

## Notes
    - Alternatively, I can create a sealed class of "EligibilityCriteria(title, value), and have objects that extend this class (e.g object Gender("Gender", trial.eligibility.gender). Add all these to a list and check object type for instances where I need specific fields. - Might have to come back to this.. 