### PR TITLE
Used memory store to access trial rather than parcelize - base implem…

### DIFF
--- a/app/src/main/java/com/example/cansearch/home/HomeActivity.kt
+++ b/app/src/main/java/com/example/cansearch/home/HomeActivity.kt
@@ -20,7 +20,7 @@ class HomeActivity : AppCompatActivity() {
 
     fun showTrial(selectedTrial: SearchScreen.SearchResult) {
         val intent = Intent(this, TrialActivity::class.java)
-        intent.putExtra("Test", selectedTrial)
+        intent.putExtra("Test", selectedTrial.id)
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/example/cansearch/search/di/SearchComponent.kt
+++ b/app/src/main/java/com/example/cansearch/search/di/SearchComponent.kt
@@ -2,6 +2,7 @@ package com.example.cansearch.search.di
 
 import com.example.cansearch.core.di.AppComponent
 import com.example.cansearch.search.ui.screens.SearchFragment
+import com.example.cansearch.search.ui.screens.TrialActivity
 import dagger.Component
 
 @Search
@@ -9,6 +10,7 @@ import dagger.Component
 interface SearchComponent {
 
     fun inject(searchFragment: SearchFragment)
+    fun inject(trialActivity: TrialActivity)
 
     @Component.Builder
     interface Builder {

--- a/app/src/main/java/com/example/cansearch/search/domain/SearchScreen.kt
+++ b/app/src/main/java/com/example/cansearch/search/domain/SearchScreen.kt
@@ -9,6 +9,8 @@ import kotlinx.android.parcel.Parcelize
 
 data class SearchScreen(val totalResults: Int, val searchResults: List<SearchResult>) {
 
+    // todo - get rid of parcelize
+
     @Parcelize
     data class SearchResult(
         val id: String,

--- a/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivity.kt
+++ b/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivity.kt
@@ -2,27 +2,35 @@ package com.example.cansearch.search.ui.screens
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.cansearch.R
-import com.example.cansearch.search.domain.SearchScreen
+import com.example.cansearch.search.di.SearchDagger
+import javax.inject.Inject
 
 class TrialActivity : AppCompatActivity() {
 
     private lateinit var viewModel: TrialActivityViewModel
+    @Inject
+    lateinit var viewModelFactory: TrialActivityViewModelFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_trial)
-        viewModel = ViewModelProviders.of(this)[TrialActivityViewModel::class.java]
+        SearchDagger.component.inject(this)
+
+        viewModel = ViewModelProviders.of(this, viewModelFactory)[TrialActivityViewModel::class.java]
 
         // todo - clean this
-        val selectedTrial = intent.getParcelableExtra<SearchScreen.SearchResult>("Test")
+        val selectedTrial = intent.getStringExtra("Test")
+        viewModel.selectedTrialActivityID.value = selectedTrial
 
-        viewModel.selectedTrial.value = selectedTrial
-
-        val ft = supportFragmentManager.beginTransaction()
-        ft.replace(R.id.fragment, TrialFragment.newInstance())
-        ft.commit()
+        viewModel.selectedTrial.observe(this, Observer { searchScreenResults ->
+            val ft = supportFragmentManager.beginTransaction()
+            ft.replace(R.id.fragment, TrialFragment.newInstance())
+            ft.commit()
+        })
+        viewModel.getSearch()
     }
 
     fun showLocation() {

--- a/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivityViewModel.kt
+++ b/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivityViewModel.kt
@@ -1,10 +1,42 @@
 package com.example.cansearch.search.ui.screens
 
+import android.annotation.SuppressLint
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.cansearch.core.data.get
+import com.example.cansearch.search.domain.FetchSearchUseCase
+import com.example.cansearch.search.domain.GetSearchUseCase
 import com.example.cansearch.search.domain.SearchScreen
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
 
-class TrialActivityViewModel : ViewModel(){
+class TrialActivityViewModel @Inject constructor(
+    private val useCases: GetSearchUseCase,
+    private val fetchSearchUseCase: FetchSearchUseCase
+) : ViewModel() {
 
+    val selectedTrialActivityID = MutableLiveData<String>()
+    val fullData = MutableLiveData<SearchScreen>()
     val selectedTrial = MutableLiveData<SearchScreen.SearchResult>()
+
+    @SuppressLint("CheckResult")
+    fun getSearch() {
+        useCases.execute("Test")
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { it ->
+
+                if (it.isSuccess()) {
+                    fullData.value = it.get()
+                    selectedTrial.value = fullData.value?.searchResults?.find { it.id == selectedTrialActivityID.value }
+                    Log.i("ASD", "ASDAS")
+                } else if (it.isFailure()){
+                    Log.i("ASD", "ASDAS")
+                    Log.i("ASD", "ASDAS")
+                }
+            }
+
+    }
 }

--- a/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivityViewModelFactory.kt
+++ b/app/src/main/java/com/example/cansearch/search/ui/screens/TrialActivityViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.example.cansearch.search.ui.screens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.cansearch.search.domain.FetchSearchUseCase
+import com.example.cansearch.search.domain.GetSearchUseCase
+import javax.inject.Inject
+
+class TrialActivityViewModelFactory @Inject constructor(
+    private val getSearchUseCases: GetSearchUseCase,
+    private val fetchSearchUseCase: FetchSearchUseCase
+) : ViewModelProvider.NewInstanceFactory() {
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        return TrialActivityViewModel(getSearchUseCases, fetchSearchUseCase) as T
+    }
+}


### PR DESCRIPTION
## Changes
    - Used memory store to access trial rather than parcelize - base implentation - NEED TO CLEAN

## TODO
    - Delete parcelize
    - Clean up the architecture - might be able to reference the singleton useCase 